### PR TITLE
Source cateogry docker-logs for logs and docker-stats for stats...

### DIFF
--- a/docker-sources/sumo-sources.json
+++ b/docker-sources/sumo-sources.json
@@ -3,7 +3,7 @@
   "sources": [
         {
             "name": "Docker-logs",
-            "category": "docker",
+            "category": "docker-logs",
             "allContainers": true,
             "collectEvents": true,
             "uri": "unix:///var/run/docker.sock",
@@ -13,7 +13,7 @@
         },
         {
             "name": "Docker-stats",
-            "category": "docker",
+            "category": "docker-stats",
             "automaticDateParsing": true,
             "forceTimeZone": false,
             "cutoffTimestamp": 0,


### PR DESCRIPTION
I found it confusing to not be able to filter by stats vs. logs - and always going by _source feels unclean.
