### PR TITLE
Collector Name improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The following environment variables are supported:
 
 * `SUMO_ACCESS_ID` - Can be used to pass the access ID instead of passing it in as a commandline argument.
 * `SUMO_ACCESS_KEY` - Can be used to pass the access key instead of passing it in as a commandline argument.
-* `SUMO_COLLECTOR_NAME` - Allows configuring the name of the Collector. The default is _collector_container_.
+* `SUMO_COLLECTOR_NAME` - Allows configuring the name of the Collector. The default is set dynamically to `/etc/hostname`.
+* `SUMO_COLLECTOR_NAME_PREFIX` - Allows configuring a prefix to the collector name.
 * `SUMO_SOURCES_JSON` - Allows specifying the path of the `sumo-sources.json` file. The default is `/etc/sumo-sources.json`.
 
 ##### Credentials

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 access_id=${SUMO_ACCESS_ID:=$1}
 access_key=${SUMO_ACCESS_KEY:=$2}
 receiver_url=${SUMO_RECEIVER_URL:=https://collectors.sumologic.com}
-collector_name=${SUMO_COLLECTOR_NAME:=collector_container}
+collector_name=${SUMO_COLLECTOR_NAME:=`hostname`}
 sources_json=${SUMO_SOURCES_JSON:=/etc/sumo-sources.json}
 
 if [ -z "$access_id" ] || [ -z "$access_key" ]; then

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 access_id=${SUMO_ACCESS_ID:=$1}
 access_key=${SUMO_ACCESS_KEY:=$2}
 receiver_url=${SUMO_RECEIVER_URL:=https://collectors.sumologic.com}
-collector_name=${SUMO_COLLECTOR_NAME_PREFIX:=''}${SUMO_COLLECTOR_NAME:=`hostname`}
+collector_name=${SUMO_COLLECTOR_NAME_PREFIX:=''}${SUMO_COLLECTOR_NAME:=`cat /etc/hostname`}
 sources_json=${SUMO_SOURCES_JSON:=/etc/sumo-sources.json}
 
 if [ -z "$access_id" ] || [ -z "$access_key" ]; then

--- a/run.sh
+++ b/run.sh
@@ -3,9 +3,8 @@
 access_id=${SUMO_ACCESS_ID:=$1}
 access_key=${SUMO_ACCESS_KEY:=$2}
 receiver_url=${SUMO_RECEIVER_URL:=https://collectors.sumologic.com}
-collector_name=${SUMO_COLLECTOR_NAME_PREFIX}${SUMO_COLLECTOR_NAME:=`hostname`}
+collector_name=${SUMO_COLLECTOR_NAME_PREFIX:=''}${SUMO_COLLECTOR_NAME:=`hostname`}
 sources_json=${SUMO_SOURCES_JSON:=/etc/sumo-sources.json}
-
 
 if [ -z "$access_id" ] || [ -z "$access_key" ]; then
 	echo "FATAL: Please provide credentials, either via the SUMO_ACCESS_ID and SUMO_ACCESS_KEY environment variables,"

--- a/run.sh
+++ b/run.sh
@@ -3,8 +3,9 @@
 access_id=${SUMO_ACCESS_ID:=$1}
 access_key=${SUMO_ACCESS_KEY:=$2}
 receiver_url=${SUMO_RECEIVER_URL:=https://collectors.sumologic.com}
-collector_name=${SUMO_COLLECTOR_NAME:=`hostname`}
+collector_name=${SUMO_COLLECTOR_NAME_PREFIX}${SUMO_COLLECTOR_NAME:=`hostname`}
 sources_json=${SUMO_SOURCES_JSON:=/etc/sumo-sources.json}
+
 
 if [ -z "$access_id" ] || [ -z "$access_key" ]; then
 	echo "FATAL: Please provide credentials, either via the SUMO_ACCESS_ID and SUMO_ACCESS_KEY environment variables,"


### PR DESCRIPTION
In some cases you want the collector to use the name of the hostname of the container. This PR allows the collector to use `/etc/hostname` if SUMO_COLLECTOR_NAME is not defined. It also allows you to prefix the name with SUMO_COLLECTOR_NAME_PREFIX