### PR TITLE
Explicitly expose 514/tcp and 514/udp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,4 @@ RUN apt-get update --quiet && \
 
 COPY run.sh run.sh 
 ENTRYPOINT ["/bin/bash", "run.sh"]
+EXPOSE 514 514/udp


### PR DESCRIPTION
Add `EXPOSE 514 514/udp` to the Dockerfile for compatibility with `rkt`.

`rkt` will only bind ports if they have been exposed in the `Dockerfile`