### PR TITLE
Adds new dockerfiles and configurations for graphite sources

### DIFF
--- a/sources-all/Dockerfile
+++ b/sources-all/Dockerfile
@@ -1,0 +1,3 @@
+FROM sumologic/collector:latest-no-source
+MAINTAINER Sumo Logic <docker@sumologic.com>
+COPY sumo-sources.json /etc/sumo-sources.json

--- a/sources-all/sumo-sources.json
+++ b/sources-all/sumo-sources.json
@@ -1,0 +1,41 @@
+{
+  "api.version": "v1",
+  "sources": [
+        {
+            "name": "Docker-logs",
+            "category": "docker",
+            "allContainers": true,
+            "collectEvents": true,
+            "uri": "unix:///var/run/docker.sock",
+            "specifiedContainers": [],
+            "multilineProcessingEnabled": false,
+            "sourceType": "DockerLog"
+        },
+        {
+            "name": "Docker-stats",
+            "category": "docker",
+            "automaticDateParsing": true,
+            "forceTimeZone": false,
+            "cutoffTimestamp": 0,
+            "uri": "unix:///var/run/docker.sock",
+            "specifiedContainers": [],
+            "allContainers": true,
+            "multilineProcessingEnabled": false,
+            "certPath": "",
+            "sourceType": "DockerStats"
+        },
+        {
+            "sourceType": "Graphite",
+            "name": "collectd-tcp",
+            "protocol": "TCP",
+            "port": 2003
+        },
+        {
+            "sourceType": "Graphite",
+            "name": "collectd-udp",
+            "protocol": "UDP",
+            "port": 2003
+        }
+   ]
+}
+

--- a/sources-graphite-tcp/Dockerfile
+++ b/sources-graphite-tcp/Dockerfile
@@ -1,0 +1,3 @@
+FROM sumologic/collector:latest-no-source
+MAINTAINER Sumo Logic <docker@sumologic.com>
+COPY sumo-sources.json /etc/sumo-sources.json

--- a/sources-graphite-tcp/sumo-sources.json
+++ b/sources-graphite-tcp/sumo-sources.json
@@ -1,0 +1,12 @@
+{
+  "api.version": "v1",
+  "sources": [
+        {
+            "sourceType": "Graphite",
+            "name": "collectd",
+            "protocol": "TCP",
+            "port": 2003
+        }
+   ]
+}
+

--- a/sources-graphite-udp/Dockerfile
+++ b/sources-graphite-udp/Dockerfile
@@ -1,0 +1,3 @@
+FROM sumologic/collector:latest-no-source
+MAINTAINER Sumo Logic <docker@sumologic.com>
+COPY sumo-sources.json /etc/sumo-sources.json

--- a/sources-graphite-udp/sumo-sources.json
+++ b/sources-graphite-udp/sumo-sources.json
@@ -1,0 +1,12 @@
+{
+  "api.version": "v1",
+  "sources": [
+        {
+            "sourceType": "Graphite",
+            "name": "collectd",
+            "protocol": "UDP",
+            "port": 2003
+        }
+   ]
+}
+


### PR DESCRIPTION
Three additional tags can be added to hub.docker.com
* sources-all
* sources-graphite-tcp
* sources-graphite-udp

Once this is done, people should be able to select the correct sources simply by adding a tag to their docker image.
For example: `sumologic/collector:sources-graphite-tcp`