### PR TITLE
make 1 min as default docker stats source interval

### DIFF
--- a/docker-sources/sumo-sources.json
+++ b/docker-sources/sumo-sources.json
@@ -22,7 +22,8 @@
             "allContainers": true,
             "multilineProcessingEnabled": false,
             "certPath": "",
-            "sourceType": "DockerStats"
+            "sourceType": "DockerStats",
+            "pollInterval": 60000
         }
    ]
 }


### PR DESCRIPTION
Add a default 1 min poll interval in docker stats source sample. For introducing the usage of this field