### PR TITLE
Add support for swarm file based secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The following environment variables are supported. You can pass environment vari
 |--------------------------|---------------|
 |`SUMO_ACCESS_ID`            |Passes the Access ID.|
 |`SUMO_ACCESS_KEY`           |Passes the Access Key.|
+|`SUMO_ACCESS_ID_FILE`       |Passes a bound file path containing Access ID.|
+|`SUMO_ACCESS_KEY_FILE`      |Passes a bound file path containing Access Key.|
 |`SUMO_CLOBBER`              | When true, if there is an existing collector with the same name, that collector will be deleted.<br><br>Default: false|
 |`SUMO_COLLECTOR_NAME`       |Configures the name of the collector. The default is set dynamically to the value in `/etc/hostname`.|
 |`SUMO_COLLECTOR_NAME_PREFIX`|Configures a prefix to the collector name. Useful when overriding `SUMO_COLLECTOR_NAME` with the Docker hostname.<br><br>Default: "collector_container-"<br><br>If you do not want a prefix, set the variable as follows: <br><br>`SUMO_COLLECTOR_NAME_PREFIX = ""`|

--- a/README.md
+++ b/README.md
@@ -111,6 +111,57 @@ To run the Docker Collection image, run the following command, supplying your ac
 
 `docker run -d -v /var/run/docker.sock:/var/run/docker.sock --name="sumo-logic-collector"  sumologic/collector:latest AccessID AccessKey`
 
+To prevent exposing your keys on the commandline, use the following command lines:
+
+```
+# be sure you have an up and running docker swarm cluster (1 node or more):
+docker swarm init
+# store your API keys using docker secret manager:
+echo AccessID | docker secret create sumo-access-id
+echo AccessKey | docker secret ceate sumo-access-key
+docker service create --name sumologic-collector --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock --mode global --secret sumo-access-id --secret sumo-secret-key -e SUMO_ACCESS_ID_FILE=/run/secret/sumo-access-id -e SUMO_ACCESS_KEY_FILE=/run/secrets/sumo-access-key sumologic/collector:latest
+```
+Using this commandline, the service will automatically be deployed to all nodes of your swarm cluster thanks to the _global_ mode.
+
+### Store and historize your configuration with docker-compose file and docker stack
+
+You can automate your swarm swarm cluster creation using docker-compose file together with the docker stack command and docker secret management.
+
+```
+# be sure you have an up and running docker swarm cluster (1 node or more):
+docker swarm init
+# store your API keys using docker secret manager:
+echo AccessID | docker secret create sumo-access-id
+echo AccessKey | docker secret ceate sumo-access-key
+
+cat > docker-compose.yml <<EOF
+version: '3.2'
+
+services:
+
+  summologic:
+    image: sumologic/collector:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    deploy:
+      mode: global
+    secrets:
+      - sumo-access-id
+      - sumo-access-key
+    environment:
+      SUMO_ACCESS_ID_FILE: /run/secrets/sumo-access-id
+      SUMO_ACCESS_KEY_FILE: /run/secrets/sumo-access-key
+
+secrets:
+  sumo-access-id:
+    external: true
+  sumo-access-key:
+    external: true
+
+EOF
+docker stack deploy --compose-file docker-compose.yml sumologic
+```
+
 The collector can be configured either with environment variables, or a volume-mounted `user.properties` file, as described in the sections below.
 
 ### Collector environment variables
@@ -149,6 +200,7 @@ For example:
 ```
 docker run other options -e SUMO_GENERATE_USER_PROPERTIES=false -v $some_path/user.properties:/opt/SumoCollector/config/user.properties sumologic/collector:$tag
 ```
+
 ### To monitor more than 40 containers
 
 By default, you can collect from up to 40 containers. To increase the limit:

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+
+if [[ $SUMO_ACCESS_ID_FILE ]]; then
+  export SUMO_ACCESS_ID=$(cat $SUMO_ACCESS_ID_FILE)
+fi
+
+if [[ $SUMO_ACCESS_KEY_FILE ]]; then
+  export SUMO_ACCESS_KEY=$(cat $SUMO_ACCESS_KEY_FILE)
+fi
+
+
 SUMO_GENERATE_USER_PROPERTIES=${SUMO_GENERATE_USER_PROPERTIES:=true}
 SUMO_ACCESS_ID=${SUMO_ACCESS_ID:=$1}
 SUMO_ACCESS_KEY=${SUMO_ACCESS_KEY:=$2}
@@ -11,7 +21,8 @@ SUMO_SYNC_SOURCES=${SUMO_SYNC_SOURCES:=false}
 generate_user_properties_file() {
     if [ -z "$SUMO_ACCESS_ID" ] || [ -z "$SUMO_ACCESS_KEY" ]; then
       echo "FATAL: Please provide credentials, either via the SUMO_ACCESS_ID and SUMO_ACCESS_KEY environment variables,"
-      echo "       or as the first two command line arguments!"
+      echo "       as the first two command line arguments,"
+      echo "       or in files references by SUMO_ACCESS_ID_FILE and SUMO_ACCESS_KEY_FILE!"
       exit 1
     fi
 


### PR DESCRIPTION
Hi,

Thanks for providing an image to run SumoLogic in containers. I am storing secrets using docker secret management that provides them as files in the containers.

This pull request allows users to store their access ID and access key in docker secrets by reading the content of the file into existing environment variables.