### PR TITLE
Keep wget around to deregister in a kubernetes preStop command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update --quiet && \
  wget -q -O /tmp/collector.deb https://collectors.sumologic.com/rest/download/deb/64 && \
  dpkg -i /tmp/collector.deb && \
  rm /tmp/collector.deb && \
- apt-get remove --quiet --force-yes -y wget && \
  apt-get clean --quiet && \
  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
For those that would prefer to have collectors cleaned up faster than the 12hr ephemeral limit, how about we leave `wget` around? With `wget` available and the access-[id|key] values in files we can deregister in a Kubernetes `preStop` command. Example with excessive logging:

```
        lifecycle:
          preStop:
            exec:
              command:
              - "/bin/sh"
              - "-c"
              - >
                echo "In preStop for sumologic sidecar" > /proc/1/fd/1
                sleep 10;
                COLLECTOR_ID=$(grep apiId /opt/SumoCollector/config/creds/main.properties | cut -c7-);
                echo "Deleting sumologic sidecar collector ${COLLECTOR_ID} from sumologics site, this will result in the sidecar process exiting" > /proc/1/fd/1;
                wget --http-user="$(cat /sumo-config/sumo-access-id)" --http-passwd="$(cat /sumo-config/sumo-access-key)" --method=DELETE https://api.us2.sumologic.com/api/v1/collectors/$COLLECTOR_ID 2> /proc/1/fd/1;
                echo "Completed deleting sumologic sidecar with retval=$?" > /proc/1/fd/1;
```