### PR TITLE
Use absolute path for entrypoint file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get update --quiet && \
  apt-get clean --quiet && \
  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY run.sh run.sh 
-ENTRYPOINT ["/bin/bash", "run.sh"]
+COPY run.sh /run.sh 
+ENTRYPOINT ["/bin/bash", "/run.sh"]


### PR DESCRIPTION
When copying and executing the entrypoint file use absolute paths.
Otherwise if we set WORKDIR in a subsequent Dockerfile the entrypoint is
broken. Particularly the no-sources Dockerfile is expected to be
inheritted from and so should specify an actual directory.