### PR TITLE
Fix escaping bug in sumo source file templating

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -49,9 +49,9 @@ generate_user_properties_file() {
 
         OLD_IFS=$IFS
         IFS=$'\n'
-        while read line; do
-          line_escape_backslashes=${line//\\/\\\\\\\\}
-          echo $(eval echo "\"${line_escape_backslashes//\"/\\\"}\"") >> ${to}
+        while read -r line; do
+          line_escape_backslashes=${line//\\/\\\\}
+          printf "%s\n" "$(eval echo "\"${line_escape_backslashes//\"/\\\"}\"")" >> ${to}
         done <${from}
         IFS=${OLD_IFS}
 


### PR DESCRIPTION
`generate_user_properties_file()` will remove double quote escapes in the generated "JSON" (quoted since it's no longer a valid JSON)

Take one line in `/etc/sumologic/sumo-sources.json.tmpl` for example,
```
...
"locator": "\"time\":\"(.*)\""
...
```
It gets turned into the following in the generated file `/etc/sumologic/sumo-sources.json`
```
...
"locator": ""time":"(.*)""
...
```

Then I found two issues with the escaping logic in the code

1. `read` without `-r` will mangle backslashes. https://github.com/koalaman/shellcheck/wiki/SC2162
I see the original code tries to over-escape the `line_escape_backslashes` to compensate, but it doesn’t work because those slashes are already gone.

2. The use of `echo` may parse backslashes too unless using `-E` option. So I prefer using `printf` here. 