### PR TITLE
SUMO-88642 Forced the collector to run as ephemeral

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The following environment variables are supported. You can pass environment vari
 |`SUMO_ACCESS_ID_FILE`       |Passes a bound file path containing Access ID.|
 |`SUMO_ACCESS_KEY_FILE`      |Passes a bound file path containing Access Key.|
 |`SUMO_CLOBBER`              | When true, if there is an existing collector with the same name, that collector will be deleted.<br><br>Default: false|
+|`SUMO_COLLECTOR_EPHEMERAL`  |When true, the collector will be deleted after it goes offline for 12 hours. <br><br>Default: true.|
 |`SUMO_COLLECTOR_NAME`       |Configures the name of the collector. The default is set dynamically to the value in `/etc/hostname`.|
 |`SUMO_COLLECTOR_NAME_PREFIX`|Configures a prefix to the collector name. Useful when overriding `SUMO_COLLECTOR_NAME` with the Docker hostname.<br><br>Default: "collector_container-"<br><br>If you do not want a prefix, set the variable as follows: <br><br>`SUMO_COLLECTOR_NAME_PREFIX = ""`|
 |`SUMO_DISABLE_SCRIPTS`       |If your organization's internal policies restrict the use of scripts, you can disable the creation of script-based script sources. When this parameter is passed, this option is removed from the Sumo web application, and script source cannot be configured.<br><br> Default: false.|

--- a/run.sh
+++ b/run.sh
@@ -116,6 +116,5 @@ $SUMO_GENERATE_USER_PROPERTIES && {
 }
 
 
-# The -t flag will force the collector to run as ephemeral
 # Don't leave our shell hanging around
-exec /opt/SumoCollector/collector console -- -t
+exec /opt/SumoCollector/collector console

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ SUMO_RECEIVER_URL=${SUMO_RECEIVER_URL:=https://collectors.sumologic.com}
 SUMO_COLLECTOR_NAME=${SUMO_COLLECTOR_NAME_PREFIX:='collector_container-'}${SUMO_COLLECTOR_NAME:=`cat /etc/hostname`}
 SUMO_SOURCES_JSON=${SUMO_SOURCES_JSON:=/etc/sumo-sources.json}
 SUMO_SYNC_SOURCES=${SUMO_SYNC_SOURCES:=false}
+SUMO_COLLECTOR_EPHEMERAL=${SUMO_COLLECTOR_EPHEMERAL:=true}
 
 generate_user_properties_file() {
     if [ -z "$SUMO_ACCESS_ID" ] || [ -z "$SUMO_ACCESS_KEY" ]; then
@@ -82,6 +83,7 @@ generate_user_properties_file() {
         ["SUMO_COLLECTOR_NAME"]="name"
         ["SUMO_SOURCES_JSON"]="sources"
         ["SUMO_SYNC_SOURCES"]="syncSources"
+        ["SUMO_COLLECTOR_EPHEMERAL"]="ephemeral"
         ["SUMO_PROXY_HOST"]="proxyHost"
         ["SUMO_PROXY_PORT"]="proxyPort"
         ["SUMO_PROXY_USER"]="proxyUser"


### PR DESCRIPTION
`exec /opt/SumoCollector/collector console -- -t` doesn't work correctly to force the collector to run as ephemeral. We would add `ephemeral=true` directly in `user.properties` file.

Already built a test image, now `CollectorRegistrationManager` would register Collector with parameters as following:
```
2018-05-09 22:46:14,570 +0000 [WrapperSimpleAppMain] INFO  com.sumologic.scala.collector.auth.CollectorRegistrationManager - [main] Registering Collector with parameters: [name=collector_container-yuting-test, credentials=AccessKeyRegistrationCredentials(suhB98nuyqZnyf,******), syncMode=Json, ephemeral=true, clobber=false, hostName=None, timeZone=None, category=None, targetCPU=None, description=None, skipAccessKeyRemoval=false]
```
`ephemeral` option is set to true now when registering the collector