### PR TITLE
Update run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,6 +18,7 @@ SUMO_COLLECTOR_NAME=${SUMO_COLLECTOR_NAME_PREFIX='collector_container-'}${SUMO_C
 SUMO_SOURCES_JSON=${SUMO_SOURCES_JSON:=/etc/sumo-sources.json}
 SUMO_SYNC_SOURCES=${SUMO_SYNC_SOURCES:=false}
 SUMO_COLLECTOR_EPHEMERAL=${SUMO_COLLECTOR_EPHEMERAL:=true}
+SUMO_COLLECTOR_HOSTNAME=${SUMO_COLLECTOR_HOSTNAME:=$(cat /etc/hostname)}
 
 generate_user_properties_file() {
     if [ -z "$SUMO_ACCESS_ID" ] || [ -z "$SUMO_ACCESS_KEY" ]; then
@@ -81,6 +82,7 @@ generate_user_properties_file() {
         ["SUMO_ACCESS_KEY"]="accesskey"
         ["SUMO_RECEIVER_URL"]="url"
         ["SUMO_COLLECTOR_NAME"]="name"
+        ["SUMO_COLLECTOR_HOSTNAME"]="hostName"
         ["SUMO_SOURCES_JSON"]="sources"
         ["SUMO_SYNC_SOURCES"]="syncSources"
         ["SUMO_COLLECTOR_EPHEMERAL"]="ephemeral"


### PR DESCRIPTION
Add support for overwriting collector hostname in the collector container deployment step. This is to fix the issue reported in https://github.com/SumoLogic/sumologic-collector-docker/issues/77. Currently if the hostname is not provided, the host name of the collector container which is the container ID is used, which is not ideal.

If supplied, it will use the supplied value. If not, it defaults to the hostname of the container (which is the current behavior). I verified the happy paths and both works. Depending on QE availability to verify this change, it can go out with collector release 3.1 or 4