### PR TITLE
Upgrade Ubuntu to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Sumo Logic <docker@sumologic.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --quiet && \
- apt-get upgrade --quiet --force-yes -y && \
- apt-get install --quiet --force-yes -y wget && \
+ apt-get upgrade --quiet --allow-downgrades --allow-remove-essential --allow-change-held-packages -y && \
+ apt-get install --quiet --allow-downgrades --allow-remove-essential --allow-change-held-packages -y wget && \
  wget -q -O /tmp/collector.deb https://collectors.sumologic.com/rest/download/deb/64 && \
  dpkg -i /tmp/collector.deb && \
  rm /tmp/collector.deb && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Sumo Logic Collector Docker Image
 # Version 0.1
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 MAINTAINER Sumo Logic <docker@sumologic.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ MAINTAINER Sumo Logic <docker@sumologic.com>
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --quiet && \
+ apt-get install -y --no-install-recommends apt-utils && \
  apt-get upgrade --quiet --allow-downgrades --allow-remove-essential --allow-change-held-packages -y && \
  apt-get install --quiet --allow-downgrades --allow-remove-essential --allow-change-held-packages -y wget && \
  wget -q -O /tmp/collector.deb https://collectors.sumologic.com/rest/download/deb/64 && \
@@ -14,5 +15,5 @@ RUN apt-get update --quiet && \
  apt-get clean --quiet && \
  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY run.sh /run.sh 
+COPY run.sh /run.sh
 ENTRYPOINT ["/bin/bash", "/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 if [[ $SUMO_ACCESS_ID_FILE ]]; then
   export SUMO_ACCESS_ID=$(cat $SUMO_ACCESS_ID_FILE)
 fi
@@ -37,7 +36,6 @@ generate_user_properties_file() {
         for f in $(find ${SUMO_SOURCES_JSON} -name '*.tmpl'); do TEMPLATE_FILES+=(${f}); done
     fi
 
-
     for from in "${TEMPLATE_FILES[@]}"
     do
         # Replace all env variables and remove .tmpl extension
@@ -59,7 +57,6 @@ generate_user_properties_file() {
         echo "INFO: Replacing environment variables from ${from} into ${to}"
 
     done
-
 
     if [ ! -e "${SUMO_SOURCES_JSON}" ]; then
       echo "FATAL: Unable to find $SUMO_SOURCES_JSON - please make sure you include it in your image!"
@@ -88,7 +85,7 @@ generate_user_properties_file() {
         ["SUMO_PROXY_PORT"]="proxyPort"
         ["SUMO_PROXY_USER"]="proxyUser"
         ["SUMO_PROXY_PASSWORD"]="proxyPassword"
-        ["SUMO_PROXY_NTLM_DOMAIN" ]="proxyNtlmDomain"
+        ["SUMO_PROXY_NTLM_DOMAIN"]="proxyNtlmDomain"
         ["SUMO_CLOBBER"]="clobber"
         ["SUMO_DISABLE_SCRIPTS"]="disableScriptSource"
         ["SUMO_JAVA_MEMORY_INIT"]="wrapper.java.initmemory"
@@ -114,7 +111,6 @@ generate_user_properties_file() {
 $SUMO_GENERATE_USER_PROPERTIES && {
     generate_user_properties_file
 }
-
 
 # Don't leave our shell hanging around
 exec /opt/SumoCollector/collector console


### PR DESCRIPTION
1. `--force-yes` flag has been deprecated. And as suggested in https://manpages.debian.org/stretch/apt/apt-get.8.en.html , replaced by `--allow-downgrades --allow-remove-essential --allow-change-held-packages`

2. Added a command in `Dockerfile` to install `apt-utils` to suppress the warning `debconf: delaying package configuration, since apt-utils is not installed` which was coming whenever a `apt-get` command was made in the container shell. Though this log line seems to be harmless (tried the collector without installing it and it worked fine, and also made some google search), but still added to avoid this log. It is adding an overhead of about 1mb in the image. And it was installed by default in the previous image (Ubuntu 14.04 base image).

3. The extra space in one of keys of the associative array seemed to be causing some issue. So removed that. 

**TESTING:**
Tested the collector by updating the `sumo-sources.json` to ingest Docker logs, Docker Stats, Local file, TCP/UDP data (by using `netcat` utility), and running the container, and verifying the logs on Long.