### PR TITLE
Add support to enable the FIPS compliant JCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following environment variables are supported. You can pass environment vari
 |`SUMO_PROXY_USER`            |Sets proxy user when a proxy server is used with authentication.|
 |`SUMO_SOURCES_JSON`          |Specifies the path to the `sumo-sources.json` file. <br><br>Default: `/etc/sumo-sources.json`. |
 |`SUMO_SYNC_SOURCES`          |If “true”, the `SUMO_SOURCES_JSON` file(s) will be continuously monitored and synchronized with the Collector's configuration. This will also disable editing of the collector in the Sumo UI. <br><br>Default: false|
+|`SUMO_FIPS_JCE`              |If "true", the FIPS 140-2 compliant Java Cryptography Extension (JCE) would be used to encrypt the data. <br><br>Default: false|
 
 ### Configure collector in user.properties file
 You can supply source configuration values using a `user.properties` file via a Docker volume mount. For information about supported properties, see [user.properties](http://help.sumologic.com/Send_Data/Installed_Collectors/05Reference_Information_for_Collector_Installation/06user.properties) in Sumo help. For information about Docker volumes, see [Use Volumes](https://docs.docker.com/engine/admin/volumes/volumes/) in Docker help.

--- a/run.sh
+++ b/run.sh
@@ -112,10 +112,11 @@ generate_user_properties_file() {
 # If the user didn't supply their own user.properties file, generate it
 $SUMO_GENERATE_USER_PROPERTIES && {
     generate_user_properties_file
-    if [ "${SUMO_FIPS_JCE}" == "true" ]; then
-        /opt/SumoCollector/script/configureFipsMode.sh
-    fi
 }
+
+if [ "${SUMO_FIPS_JCE}" == "true" ]; then
+    /opt/SumoCollector/script/configureFipsMode.sh
+fi
 
 # Don't leave our shell hanging around
 exec /opt/SumoCollector/collector console

--- a/run.sh
+++ b/run.sh
@@ -112,6 +112,9 @@ generate_user_properties_file() {
 # If the user didn't supply their own user.properties file, generate it
 $SUMO_GENERATE_USER_PROPERTIES && {
     generate_user_properties_file
+    if [ "${SUMO_FIPS_JCE}" == "true" ]; then
+        /opt/SumoCollector/script/configureFipsMode.sh
+    fi
 }
 
 # Don't leave our shell hanging around


### PR DESCRIPTION
**Testing done:**
_I) With the collector which supported FIPS mode:_ 
1. Ran the docker container with `-e SUMO_FIPS_JCE=true` once with `SUMO_GENERATE_USER_PROPERTIES=false` and once without `SUMO_GENERATE_USER_PROPERTIES=false`. 
  a) Ran the `docker logs <containerId>` command and checked the `configureFipsMode.sh` log lines.
  b) Ran `sudo service collector status`, and verified the collector was running.
  c) Checked the `collector.log` file for the `JceProviders.scala` log line (`Added Bouncy Castle FIPS provider ..`)

2. Ran the docker container once with `-e SUMO_FIPS_JCE=false` and another without the flag once with `SUMO_GENERATE_USER_PROPERTIES=false` and once without `SUMO_GENERATE_USER_PROPERTIES=false`.
  a) No extra logs of `configureFipsMode.sh` in `docker logs <containerId>`.
  b) Ran `sudo service collector status`, and verified the collector was running.
  c) Searched the `collector.log` file for the `Added Bouncy Castle FIPS provider ..` log line, and it wasn't present. 

_II) With the collector which doesn't support FIPS mode (current production):_
`docker logs <containerId>` showed the `configureFipsMode.sh` file couldn't be found. But there was no issue in the collector getting started. Checked by running the command `sudo service collector status`. 