### PR TITLE
Add support for installation token

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,32 +120,34 @@ The collector can be configured either with environment variables, or a volume-m
 The following environment variables are supported. You can pass environment variables to the `docker run` command with the `-e` flag.
 
 
-|Environment Variable      |Description    |
-|--------------------------|---------------|
-|`SUMO_ACCESS_ID`            |Passes the Access ID.|
-|`SUMO_ACCESS_KEY`           |Passes the Access Key.|
-|`SUMO_ACCESS_ID_FILE`       |Passes a bound file path containing Access ID.|
-|`SUMO_ACCESS_KEY_FILE`      |Passes a bound file path containing Access Key.|
-|`SUMO_CLOBBER`              | When true, if there is an existing collector with the same name, that collector will be deleted.<br><br>Default: false|
-|`SUMO_COLLECTOR_EPHEMERAL`  |When true, the collector will be deleted after it goes offline for 12 hours. <br><br>Default: true.|
-|`SUMO_COLLECTOR_FIELDS`     |Optional comma separated list of key=value fields to be added to the collector e.g. `_budget=Dev_20,cluster=k8s.dev`. Does nothing if `SUMO_GENERATE_USER_PROPERTIES` is set to “false”.|
-|`SUMO_COLLECTOR_NAME`       |Configures the name of the collector. The default is set dynamically to the value in `/etc/hostname`.|
-|`SUMO_COLLECTOR_NAME_PREFIX`|Configures a prefix to the collector name. Useful when overriding `SUMO_COLLECTOR_NAME` with the Docker hostname.<br><br>Default: "collector_container-"<br><br>If you do not want a prefix, set the variable as follows: <br><br>`SUMO_COLLECTOR_NAME_PREFIX = ""`|
-|`SUMO_COLLECTOR_HOSTNAME`   |Sets the host name of the machine on which the Collector container is running.<br><br> Default: The container ID.|
-|`SUMO_DISABLE_SCRIPTS`       |If your organization's internal policies restrict the use of scripts, you can disable the creation of script-based script sources. When this parameter is passed, this option is removed from the Sumo web application, and script source cannot be configured.<br><br> Default: false.|
-|`SUMO_GENERATE_USER_PROPERTIES`|Set this variable to “false” if you are providing the collector configuration settings using a `user.properties` file via a Docker volume mount.|
+|Environment Variable                |Description    |
+|------------------------------------|---------------|
+|`SUMO_ACCESS_ID`                    |Passes the Access ID.|
+|`SUMO_ACCESS_KEY`                   |Passes the Access Key.|
+|`SUMO_INSTALLATION_TOKEN`           |Passes the Installation Token.|
+|`SUMO_ACCESS_ID_FILE`               |Passes a bound file path containing Access ID.|
+|`SUMO_ACCESS_KEY_FILE`              |Passes a bound file path containing Access Key.|
+|`SUMO_INSTALLATION_TOKEN_FILE`      |Passes a bound file path containing the Installation Token.|
+|`SUMO_CLOBBER`                      |When true, if there is an existing collector with the same name, that collector will be deleted.<br><br>Default: false|
+|`SUMO_COLLECTOR_EPHEMERAL`          |When true, the collector will be deleted after it goes offline for 12 hours. <br><br>Default: true.|
+|`SUMO_COLLECTOR_FIELDS`             |Optional comma separated list of key=value fields to be added to the collector e.g. `_budget=Dev_20,cluster=k8s.dev`. Does nothing if `SUMO_GENERATE_USER_PROPERTIES` is set to “false”.|
+|`SUMO_COLLECTOR_NAME`               |Configures the name of the collector. The default is set dynamically to the value in `/etc/hostname`.|
+|`SUMO_COLLECTOR_NAME_PREFIX`        |Configures a prefix to the collector name. Useful when overriding `SUMO_COLLECTOR_NAME` with the Docker hostname.<br><br>Default: "collector_container-"<br><br>If you do not want a prefix, set the variable as follows: <br><br>`SUMO_COLLECTOR_NAME_PREFIX = ""`|
+|`SUMO_COLLECTOR_HOSTNAME`           |Sets the host name of the machine on which the Collector container is running.<br><br> Default: The container ID.|
+|`SUMO_DISABLE_SCRIPTS`              |If your organization's internal policies restrict the use of scripts, you can disable the creation of script-based script sources. When this parameter is passed, this option is removed from the Sumo web application, and script source cannot be configured.<br><br> Default: false.|
+|`SUMO_GENERATE_USER_PROPERTIES`     |Set this variable to “false” if you are providing the collector configuration settings using a `user.properties` file via a Docker volume mount.|
 |`SUMO_GENERATE_COLLECTOR_PROPERTIES`|Set this variable to “false” if you are providing the collector configuration settings using a `collector.properties` file via a Docker volume mount.|
-|`SUMO_JAVA_MEMORY_INIT`      |Sets the initial java heap size (in MB). <br><br>Default: 64|
-|`SUMO_JAVA_MEMORY_MAX`       |Sets the maximum java heap size (in MB). <br><br>Default: 128.|
-|`SUMO_PROXY_HOST`            |Sets proxy host when a proxy server is used.|
-|`SUMO_PROXY_NTLM_DOMAIN`     |Sets proxy NTLM domain when a proxy server is used with NTLM authentication.|
-|`SUMO_PROXY_PASSWORD`        |Sets proxy password when a proxy server is used with authentication.|
-|`SUMO_PROXY_PORT`            |Sets proxy port when a proxy server is used.|
-|`SUMO_PROXY_USER`            |Sets proxy user when a proxy server is used with authentication.|
-|`SUMO_SOURCES_JSON`          |Specifies the path to the `sumo-sources.json` file. <br><br>Default: `/etc/sumo-sources.json`. |
-|`SUMO_SYNC_SOURCES`          |If “true”, the `SUMO_SOURCES_JSON` file(s) will be continuously monitored and synchronized with the Collector's configuration. This will also disable editing of the collector in the Sumo UI. <br><br>Default: false|
-|`SUMO_FIPS_JCE`              |If "true", the FIPS 140-2 compliant Java Cryptography Extension (JCE) would be used to encrypt the data. <br><br>Default: false|
-|`SUMO_UDP_READ_BUFFER_SIZE`  |Sets the datagram size of the UDP messages (in bytes) <br><br>Default: 2048<br><br>Max: 65535|
+|`SUMO_JAVA_MEMORY_INIT`             |Sets the initial java heap size (in MB). <br><br>Default: 64|
+|`SUMO_JAVA_MEMORY_MAX`              |Sets the maximum java heap size (in MB). <br><br>Default: 128.|
+|`SUMO_PROXY_HOST`                   |Sets proxy host when a proxy server is used.|
+|`SUMO_PROXY_NTLM_DOMAIN`            |Sets proxy NTLM domain when a proxy server is used with NTLM authentication.|
+|`SUMO_PROXY_PASSWORD`               |Sets proxy password when a proxy server is used with authentication.|
+|`SUMO_PROXY_PORT`                   |Sets proxy port when a proxy server is used.|
+|`SUMO_PROXY_USER`                   |Sets proxy user when a proxy server is used with authentication.|
+|`SUMO_SOURCES_JSON`                 |Specifies the path to the `sumo-sources.json` file. <br><br>Default: `/etc/sumo-sources.json`. |
+|`SUMO_SYNC_SOURCES`                 |If “true”, the `SUMO_SOURCES_JSON` file(s) will be continuously monitored and synchronized with the Collector's configuration. This will also disable editing of the collector in the Sumo UI. <br><br>Default: false|
+|`SUMO_FIPS_JCE`                     |If "true", the FIPS 140-2 compliant Java Cryptography Extension (JCE) would be used to encrypt the data. <br><br>Default: false|
+|`SUMO_UDP_READ_BUFFER_SIZE`         |Sets the datagram size of the UDP messages (in bytes) <br><br>Default: 2048<br><br>Max: 65535|
 
 ### Configure collector in user.properties file
 You can supply source configuration values using a `user.properties` file via a Docker volume mount. For information about supported properties, see [user.properties](http://help.sumologic.com/Send_Data/Installed_Collectors/05Reference_Information_for_Collector_Installation/06user.properties) in Sumo help. For information about Docker volumes, see [Use Volumes](https://docs.docker.com/engine/admin/volumes/volumes/) in Docker help.

--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,10 @@ if [[ $SUMO_ACCESS_KEY_FILE ]]; then
   export SUMO_ACCESS_KEY=$(cat $SUMO_ACCESS_KEY_FILE)
 fi
 
+if [[ $SUMO_INSTALLATION_TOKEN_FILE ]]; then
+  export SUMO_INSTALLATION_TOKEN=$(cat $SUMO_INSTALLATION_TOKEN_FILE)
+fi
+
 SUMO_GENERATE_USER_PROPERTIES=${SUMO_GENERATE_USER_PROPERTIES:=true}
 SUMO_GENERATE_COLLECTOR_PROPERTIES=${SUMO_GENERATE_COLLECTOR_PROPERTIES:=true}
 SUMO_ACCESS_ID=${SUMO_ACCESS_ID:=$1}
@@ -42,11 +46,17 @@ generate_collector_properties_file() {
 }
 
 generate_user_properties_file() {
-    if [ -z "$SUMO_ACCESS_ID" ] || [ -z "$SUMO_ACCESS_KEY" ]; then
-      echo "FATAL: Please provide credentials, either via the SUMO_ACCESS_ID and SUMO_ACCESS_KEY environment variables,"
-      echo "       as the first two command line arguments,"
-      echo "       or in files references by SUMO_ACCESS_ID_FILE and SUMO_ACCESS_KEY_FILE!"
-      exit 1
+    if [ -z "$SUMO_ACCESS_ID" ] && [ -z "$SUMO_ACCESS_KEY" ]; then
+      if [ -z "$SUMO_INSTALLATION_TOKEN" ]; then
+        echo "FATAL: Please provide credentials via:"
+        echo "       * the SUMO_ACCESS_ID and SUMO_ACCESS_KEY environment variables,"
+        echo "       * as the first two command line arguments, or"
+        echo "       * in files references by SUMO_ACCESS_ID_FILE and SUMO_ACCESS_KEY_FILE"
+        echo "       You can also provide an installation token via:"
+        echo "       * the SUMO_INSTALLATION_TOKEN environment variable, or"
+        echo "       * in a file referenced by the SUMO_INSTALLATION_TOKEN_FILE environment variable"
+        exit 1
+      fi
     fi
 
     # Support using env as replacement within sources.
@@ -99,6 +109,7 @@ generate_user_properties_file() {
     SUPPORTED_OPTIONS=(
         ["SUMO_ACCESS_ID"]="accessid"
         ["SUMO_ACCESS_KEY"]="accesskey"
+        ["SUMO_INSTALLATION_TOKEN"]="token"
         ["SUMO_RECEIVER_URL"]="url"
         ["SUMO_COLLECTOR_NAME"]="name"
         ["SUMO_COLLECTOR_HOSTNAME"]="hostName"


### PR DESCRIPTION
Previously, this docker image only supported providing credentials via `SUMO_ACCESS_ID` and `SUMO_ACCESS_KEY`, which meant the creds needed to be associated with a specific user.
Installation token support was added into the product, but got missed in this image.

This PR adds support for using an installation token via a `SUMO_INSTALLATION_TOKEN` env var or via a file, specified by the `SUMO_INSTALLATION_TOKEN_FILE` env var.