### PR TITLE
Upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Sumo Logic Collector Docker Image
 # Version 0.1
 
-FROM ubuntu:18.04
-MAINTAINER Sumo Logic <docker@sumologic.com>
+FROM ubuntu:20.04
+LABEL org.opencontainers.image.authors="Sumo Logic <docker@sumologic.com>"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --quiet && \


### PR DESCRIPTION
Upgrade base image to latest Ubuntu LTS image (20.04).
Reference: https://wiki.ubuntu.com/Releases

Replace deprecated `MAINTAINER` instruction with `LABEL`.
Reference: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated