### PR TITLE
Add an option to specify `category` in generated `user.properties`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The following environment variables are supported. You can pass environment vari
 |`SUMO_ACCESS_ID_FILE`               |Passes a bound file path containing Access ID.|
 |`SUMO_ACCESS_KEY_FILE`              |Passes a bound file path containing Access Key.|
 |`SUMO_INSTALLATION_TOKEN_FILE`      |Passes a bound file path containing the Installation Token.|
+|`SUMO_CATEGORY`                     |Specify collector Category.|
 |`SUMO_CLOBBER`                      |When true, if there is an existing collector with the same name, that collector will be deleted.<br><br>Default: false|
 |`SUMO_COLLECTOR_EPHEMERAL`          |When true, the collector will be deleted after it goes offline for 12 hours. <br><br>Default: true.|
 |`SUMO_COLLECTOR_FIELDS`             |Optional comma separated list of key=value fields to be added to the collector e.g. `_budget=Dev_20,cluster=k8s.dev`. Does nothing if `SUMO_GENERATE_USER_PROPERTIES` is set to “false”.|

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ The following environment variables are supported. You can pass environment vari
 |`SUMO_ACCESS_ID_FILE`               |Passes a bound file path containing Access ID.|
 |`SUMO_ACCESS_KEY_FILE`              |Passes a bound file path containing Access Key.|
 |`SUMO_INSTALLATION_TOKEN_FILE`      |Passes a bound file path containing the Installation Token.|
-|`SUMO_CATEGORY`                     |Specify collector Category.|
 |`SUMO_CLOBBER`                      |When true, if there is an existing collector with the same name, that collector will be deleted.<br><br>Default: false|
+|`SUMO_COLLECTOR_CATEGORY`           |Specify collector Category.|
 |`SUMO_COLLECTOR_EPHEMERAL`          |When true, the collector will be deleted after it goes offline for 12 hours. <br><br>Default: true.|
 |`SUMO_COLLECTOR_FIELDS`             |Optional comma separated list of key=value fields to be added to the collector e.g. `_budget=Dev_20,cluster=k8s.dev`. Does nothing if `SUMO_GENERATE_USER_PROPERTIES` is set to “false”.|
 |`SUMO_COLLECTOR_NAME`               |Configures the name of the collector. The default is set dynamically to the value in `/etc/hostname`.|

--- a/run.sh
+++ b/run.sh
@@ -127,7 +127,7 @@ generate_user_properties_file() {
         ["SUMO_JAVA_MEMORY_INIT"]="wrapper.java.initmemory"
         ["SUMO_JAVA_MEMORY_MAX"]="wrapper.java.maxmemory"
         ["SUMO_COLLECTOR_FIELDS"]="fields"
-        ["SUMO_CATEGORY"]="category"
+        ["SUMO_COLLECTOR_CATEGORY"]="category"
     )
 
     USER_PROPERTIES=""

--- a/run.sh
+++ b/run.sh
@@ -127,6 +127,7 @@ generate_user_properties_file() {
         ["SUMO_JAVA_MEMORY_INIT"]="wrapper.java.initmemory"
         ["SUMO_JAVA_MEMORY_MAX"]="wrapper.java.maxmemory"
         ["SUMO_COLLECTOR_FIELDS"]="fields"
+        ["SUMO_CATEGORY"]="category"
     )
 
     USER_PROPERTIES=""


### PR DESCRIPTION
**The problem**

I don't want to add category to each source item because they are all the same per environment.
It is clunky to specify different value according to each environment.

**The cause**

There is no way to specify category for auto-generated `user.properties`.

**The goal**

Provide an option to add category to auto-generated `user.properties`.

**The solution**

* Enable this by an environment variable as other settings (in `run.sh`)
* Update the `README`